### PR TITLE
nginx 기반 LB 추가 (scale up 2까지만 가능)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,27 @@ k6 run ./generator/traffic.js
 ```
 
 ### [공식문서](https://k6.io/docs/)
+
+### 로드 밸런서 추가하기
+
+1. docker compose를 활용해, 동일한 was 이미지를 2개 띄우기
+```
+docker compose up --scale app=2
+```
+
+띄워진 컨테이너 확인
+
+![image](https://github.com/JavaBlooming-In-Spring/System-Design-Interview/assets/76645095/fc1af713-da59-4977-849c-085b803a2316)
+
+
+2. 요청을 2번 보냈을때, 로드 밸런싱이 되는지 확인
+
+![image](https://github.com/JavaBlooming-In-Spring/System-Design-Interview/assets/76645095/b5feb147-0a62-47c8-849f-ad0bfaef37f9)
+
+    a. app-2 컨테이너 종료해보기
+    
+![image](https://github.com/JavaBlooming-In-Spring/System-Design-Interview/assets/76645095/5765b9f2-aff4-487c-96bf-f3f2686186da)
+
+    b. 다시 요청을 보냈을때 app-1이 요청을 받는지 확인하기
+
+![image](https://github.com/JavaBlooming-In-Spring/System-Design-Interview/assets/76645095/8e4e9514-7d57-41db-94e6-c3802f5d4111)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,9 @@
 version: "3"
 services:
   app:
-    container_name: app
     image: arm64v8/amazoncorretto:17-alpine-jdk
     ports:
-      - "8080:8080"
+      - "8080-8081:8080"
     volumes:
       - ./src:/app/src
       - ./gradle:/app/gradle
@@ -22,6 +21,17 @@ services:
       SPRING_DATASOURCE_PASSWORD: "123"
     depends_on:
       - my-mysql
+
+  nginx:
+    image: nginx:latest
+    #    extra_hosts:
+    #      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - app
+    ports:
+      - "80:80"
 
   my-mysql:
     container_name: my-mysql

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,19 @@
+user nginx;
+events {
+  worker_connections 1000;
+}
+
+http {
+
+  upstream all {
+    server app:8080 fail_timeout=300;
+    server app:8081 fail_timeout=300;
+  }
+
+  server {
+    listen 80;
+    location / {
+		  proxy_pass http://all;
+    }
+  }
+}

--- a/prometheus/config/prometheus.yaml
+++ b/prometheus/config/prometheus.yaml
@@ -22,6 +22,7 @@ scrape_configs:
     static_configs:
       - targets:
           - "host.docker.internal:8080"
+          - "host.docker.internal:8081"
   - job_name: "mysql"
     metrics_path: "/metrics"
     scrape_interval: 5s

--- a/src/main/java/system/design/interview/TestController.java
+++ b/src/main/java/system/design/interview/TestController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
     @GetMapping("/test")
     public String test() {
+        log.info("yoyo~!");
         return "test";
     }
 }


### PR DESCRIPTION
<img width="1211" alt="image" src="https://github.com/JavaBlooming-In-Spring/System-Design-Interview/assets/26597702/d9360bb6-155f-46e4-a788-1f6b0705bc83">

nginx에서 LB가 잘 동작하여 `localhost:80/test`로 쐈을 때 app-1, app-2에 나눠서 `yoyo~!` 가 찍힌 걸 볼 수 있습니당

포트가 한정적이라 scale up은 딱 2대까지 하드코딩된 상태고 더 늘리려면 8080-8081로 되어있는 포트 range를 늘려주면서 프로메테우스에도 늘어난 호스트와 포트들을 추가해주어야 합니다 (file changes 참고)

README는 어차피 뱃사공이 #4까지 만들꺼라서 뱃사공꺼 가져왔습니다~

close: #4 